### PR TITLE
Build failure fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(${EXECUTABLE_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/player-lib-install/lib/libplayerc.so
 )
 
+add_dependencies(${EXECUTABLE_NAME} player-lib)
+
 ament_target_dependencies(${EXECUTABLE_NAME}
   "rclcpp"
   "nav_msgs"

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,9 @@
   <author>Arne Hitzmann</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rclcpp</depend>  
+  <depend>libgeos++-dev</depend>
+  <depend>subversion</depend>
+  <depend>rclcpp</depend>
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
Hi just trying to get the eloquent version up and running as this seems to be a good package to try out ROS for university with my vacuum. Figured out that the `libgeos++-dev` and `subversion` dependencies are missing while building inside an eloquent docker container. Also I first had the problem that I had to run the build twice because of a missing `libplayerc/playerc.h`:
```
root@707d8a30f45b:/dev_ws# colcon build                                                                                       
Starting >>> xiaomi_bridge                                                                                                    
[Processing: xiaomi_bridge]                                                                                                   
--- stderr: xiaomi_bridge                                                                                                     
make[2]: *** No rule to make target 'player-lib-install/lib/libplayerc.so', needed by 'xiaomi_bridge_node'.  Stop.            
make[2]: *** Waiting for unfinished jobs....                                                                                  
In file included from /dev_ws/src/xiaomi_bridge/src/xiaomi_player_interface.cpp:1:0:                                          
/dev_ws/src/xiaomi_bridge/include/xiaomi_bridge/xiaomi_player_interface.h:4:10: fatal error: libplayerc/playerc.h: No such fil
e or directory                                                                                                                
 #include <libplayerc/playerc.h>                                                                                              
          ^~~~~~~~~~~~~~~~~~~~~~                                                                                              
compilation terminated.                                                                                                       
make[2]: *** [CMakeFiles/xiaomi_bridge_node.dir/src/xiaomi_player_interface.cpp.o] Error 1                                    
In file included from /dev_ws/src/xiaomi_bridge/include/xiaomi_bridge/xiaomi_topic_handler.h:19:0,                            
                 from /dev_ws/src/xiaomi_bridge/src/xiaomi_bridge_node.cpp:1:                                                 
/dev_ws/src/xiaomi_bridge/include/xiaomi_bridge/xiaomi_player_interface.h:4:10: fatal error: libplayerc/playerc.h: No such fil
e or directory                                                                                                                
 #include <libplayerc/playerc.h>                                                                                              
          ^~~~~~~~~~~~~~~~~~~~~~                                                                                              
compilation terminated.                                                                                                       
make[2]: *** [CMakeFiles/xiaomi_bridge_node.dir/src/xiaomi_bridge_node.cpp.o] Error 1                                         
In file included from /dev_ws/src/xiaomi_bridge/include/xiaomi_bridge/xiaomi_topic_handler.h:19:0,                            
                 from /dev_ws/src/xiaomi_bridge/src/xiaomi_topic_handler.cpp:1:                                               
/dev_ws/src/xiaomi_bridge/include/xiaomi_bridge/xiaomi_player_interface.h:4:10: fatal error: libplayerc/playerc.h: No such fil
e or directory                                                                                                                
 #include <libplayerc/playerc.h>                                                                                              
          ^~~~~~~~~~~~~~~~~~~~~~                                                                                              
compilation terminated.                                                                                                       
make[2]: *** [CMakeFiles/xiaomi_bridge_node.dir/src/xiaomi_topic_handler.cpp.o] Error 1                                       
make[1]: *** [CMakeFiles/xiaomi_bridge_node.dir/all] Error 2
...
```
After inserting a dependency in the `CMakeLists.txt` I was able to resolve that issue.

Only think not working out of the box now and which really bugs me sofar is a missing shared object `libplayerc.so.3.1` when calling the `xiaomi_bridge_node`:
```
root@dbd0868e45ac:/dev_ws# ros2 launch xiaomi_bridge xiaomi_bringup.launch.py
[INFO] [launch]: All log files can be found below /root/.ros/log/2020-05-12-20-26-45-230366-dbd0868e45ac-22879
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [robot_state_publisher-1]: process started with pid [22902]
[INFO] [xiaomi_bridge_node-2]: process started with pid [22903]
[ERROR] [xiaomi_bridge_node-2]: process has died [pid 22903, exit code 127, cmd '/dev_ws/install/xiaomi_bridge/lib/xiaomi_bridge/xiaomi_bridge_node --ros-args --params-file /dev_ws/install/xiaomi_bridge/share/xiaomi_bridge/config/robot_config.yaml'].
[xiaomi_bridge_node-2] /dev_ws/install/xiaomi_bridge/lib/xiaomi_bridge/xiaomi_bridge_node: error while loading shared libraries: libplayerc.so.3.1: cannot open shared object file: No such file or directory

[robot_state_publisher-1] Initialize urdf model from file: /dev_ws/install/xiaomi_bridge/share/xiaomi_bridge/urdf/xiaomi_gen1.urdf
```
By adding it manually to $LD_LIBRARY_PATH I can fix it but that's not a permanent fix. Somehow it has to be moved somehow but still learning CMake and haven't yet figured this out.

Sry btw if this PR doesn't make sense etc. Just getting started with the whole ROS universe and I'm also not experienced at all with CPP and CMake!^^